### PR TITLE
Add v to version and set prerelease output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/check-version",
-      "version": "1.0.5",
-      "license": "MIT",
+      "version": "1.0.6",
+      "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.5.4",
         "zod": "^3.22.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Asserts package version is the same or higher than latest published tag",
   "main": "dist/index.js",
   "scripts": {

--- a/src/__tests__/checkVersion.test.ts
+++ b/src/__tests__/checkVersion.test.ts
@@ -97,19 +97,15 @@ describe('checkVersion', function () {
     const checkVersion = new CheckVersion(core, fs)
     const setOutputStub = sinon.stub(core, 'setOutput')
 
-    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1', false)
+    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1')
     expect(setOutputStub.calledWithExactly('version', 'v1.1.1')).to.equal(true)
   })
 
-  test('assert is_prerelease output is true if - present in version', async function () {
+  test('assert is_prerelease output is true if `-` char present in version', async function () {
     const checkVersion = new CheckVersion(core, fs)
     const setOutputStub = sinon.stub(core, 'setOutput')
 
-    let res = await checkVersion.assertComparisons(
-      '0.1.1',
-      '1.1.1-alpha',
-      false
-    )
+    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1-alpha')
     expect(setOutputStub.calledWithExactly('is_prerelease', true)).to.equal(
       true
     )
@@ -119,7 +115,7 @@ describe('checkVersion', function () {
     const checkVersion = new CheckVersion(core, fs)
     const setOutputStub = sinon.stub(core, 'setOutput')
 
-    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1', false)
+    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1')
     expect(setOutputStub.calledWithExactly('is_prerelease', false)).to.equal(
       true
     )

--- a/src/__tests__/checkVersion.test.ts
+++ b/src/__tests__/checkVersion.test.ts
@@ -84,12 +84,44 @@ describe('checkVersion', function () {
     expect(setFailedStubx.calledOnce).to.equal(true)
     expect(res).to.equal(false)
   })
-})
 
-test('assert same version passes with failOnSameVersion false', async function () {
-  const checkVersion = new CheckVersion(core, fs)
+  test('assert same version passes with failOnSameVersion false', async function () {
+    const checkVersion = new CheckVersion(core, fs)
 
-  let res = await checkVersion.assertComparisons('0.1.1', '0.1.1', false)
+    let res = await checkVersion.assertComparisons('0.1.1', '0.1.1', false)
 
-  expect(res).to.equal(true)
+    expect(res).to.equal(true)
+  })
+
+  test('assert v is added to version output', async function () {
+    const checkVersion = new CheckVersion(core, fs)
+    const setOutputStub = sinon.stub(core, 'setOutput')
+
+    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1', false)
+    expect(setOutputStub.calledWithExactly('version', 'v1.1.1')).to.equal(true)
+  })
+
+  test('assert is_prerelease output is true if - present in version', async function () {
+    const checkVersion = new CheckVersion(core, fs)
+    const setOutputStub = sinon.stub(core, 'setOutput')
+
+    let res = await checkVersion.assertComparisons(
+      '0.1.1',
+      '1.1.1-alpha',
+      false
+    )
+    expect(setOutputStub.calledWithExactly('is_prerelease', true)).to.equal(
+      true
+    )
+  })
+
+  test('assert is_prerelease output is false if - not present in version', async function () {
+    const checkVersion = new CheckVersion(core, fs)
+    const setOutputStub = sinon.stub(core, 'setOutput')
+
+    let res = await checkVersion.assertComparisons('0.1.1', '1.1.1', false)
+    expect(setOutputStub.calledWithExactly('is_prerelease', false)).to.equal(
+      true
+    )
+  })
 })

--- a/src/checkVersion.ts
+++ b/src/checkVersion.ts
@@ -21,7 +21,10 @@ const packageParser = z.object({
 })
 
 export class CheckVersion {
-  constructor(private core: typeof ghCore, private fs: typeof fsPromises) {}
+  constructor(
+    private core: typeof ghCore,
+    private fs: typeof fsPromises
+  ) {}
 
   async checkVersion(
     location: string,
@@ -116,16 +119,19 @@ export class CheckVersion {
     packageTag: string,
     failOnSameVersion = true
   ): Promise<boolean> {
+    this.core.setOutput('build_date', new Date())
+    this.core.setOutput('version', `v${packageTag}`)
+    this.core.setOutput('is_prerelease', packageTag.includes('-'))
+
     if (semver.compare(newestGithubTag, packageTag) === 1) {
       this.core.setOutput('is_new_version', false)
+
       this.core.setFailed(
         `Newest tag: ${newestGithubTag} is a higher version than package.json: ${packageTag}`
       )
       return false
     } else if (semver.compare(newestGithubTag, packageTag) === -1) {
-      this.core.setOutput('version', packageTag)
       this.core.setOutput('is_new_version', true)
-      this.core.setOutput('build_date', new Date())
 
       console.log(
         `Newest tag: ${newestGithubTag} is a lower version than package.json: ${packageTag} \n so we must be releasing new version`
@@ -133,7 +139,7 @@ export class CheckVersion {
       return true
     } else if (semver.compare(newestGithubTag, packageTag) === 0) {
       this.core.setOutput('is_new_version', false)
-      this.core.setOutput('is_prerelease', false)
+
       console.log(
         `Newest tag: ${newestGithubTag} is the same version as package.json: ${packageTag} so not a new version`
       )


### PR DESCRIPTION
Prepends `v` on `version` output.
Returns `true` for `is_prerelease` output if `-` is present in the version.

Current tags for releasing using this action's outputs
<img width="173" alt="image" src="https://github.com/digicatapult/check-version/assets/40722025/82fd8198-901e-4617-aba9-fa0a9d8cd6fb">

Desired tags for releasing (produced by old `check-version.sh`)
<img width="207" alt="image" src="https://github.com/digicatapult/check-version/assets/40722025/577cf821-9f62-4c62-b6a9-9cace0da46b6">


