### PR TITLE
Add `npm_release_tag` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,6 @@ build_date:
     description: 'date of the build'
 is_prerelease:
     description: 'boolean indicating if this is a prerelease'
+npm_release_tag:
+    description: 'release tag for npm packages. `latest` or `next`'
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ outputs:
     description: 'date of the build'
   is_prerelease:
     description: 'boolean indicating if this is a prerelease true = yes '
+  npm_release_tag:
+    description: 'release tag for npm packages. `latest` or `next`'
 
 runs:
   using: 'node16'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/check-version",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Asserts package version is the same or higher than latest published tag",
   "main": "dist/index.js",
   "scripts": {

--- a/src/__tests__/checkVersion.test.ts
+++ b/src/__tests__/checkVersion.test.ts
@@ -101,7 +101,7 @@ describe('checkVersion', function () {
     expect(setOutputStub.calledWithExactly('version', 'v1.1.1')).to.equal(true)
   })
 
-  test('assert is_prerelease output is true if `-` char present in version', async function () {
+  test('assert is_prerelease and npm_release_tag output if `-` char present in version', async function () {
     const checkVersion = new CheckVersion(core, fs)
     const setOutputStub = sinon.stub(core, 'setOutput')
 
@@ -109,9 +109,12 @@ describe('checkVersion', function () {
     expect(setOutputStub.calledWithExactly('is_prerelease', true)).to.equal(
       true
     )
+    expect(setOutputStub.calledWithExactly('npm_release_tag', 'next')).to.equal(
+      true
+    )
   })
 
-  test('assert is_prerelease output is false if - not present in version', async function () {
+  test('assert is_prerelease and npm_release_tag output if `-` char NOT in version', async function () {
     const checkVersion = new CheckVersion(core, fs)
     const setOutputStub = sinon.stub(core, 'setOutput')
 
@@ -119,5 +122,8 @@ describe('checkVersion', function () {
     expect(setOutputStub.calledWithExactly('is_prerelease', false)).to.equal(
       true
     )
+    expect(
+      setOutputStub.calledWithExactly('npm_release_tag', 'latest')
+    ).to.equal(true)
   })
 })

--- a/src/checkVersion.ts
+++ b/src/checkVersion.ts
@@ -119,9 +119,12 @@ export class CheckVersion {
     packageTag: string,
     failOnSameVersion = true
   ): Promise<boolean> {
+    const isPrerelease = packageTag.includes('-')
+
     this.core.setOutput('build_date', new Date())
     this.core.setOutput('version', `v${packageTag}`)
-    this.core.setOutput('is_prerelease', packageTag.includes('-'))
+    this.core.setOutput('is_prerelease', isPrerelease)
+    this.core.setOutput('npm_release_tag', isPrerelease ? 'next' : 'latest')
 
     if (semver.compare(newestGithubTag, packageTag) === 1) {
       this.core.setOutput('is_new_version', false)


### PR DESCRIPTION
Replicate `npm_release_tag` output of the old `check-version.sh`
```
  if [[ $CURRENT_VERSION =~ [-] ]]; then
    echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT
    echo "NPM_RELEASE_TAG=next" >> $GITHUB_OUTPUT
  else
    echo "IS_PRERELEASE=false" >> $GITHUB_OUTPUT
    echo "NPM_RELEASE_TAG=latest" >> $GITHUB_OUTPUT
  fi
```