### PR TITLE
Bug - add missing input for `tag_regex` and log outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with:
 | poetry_package_location |    N     |      `./`        | Provide path to pyproject.toml file. Default is `./`                                                             |
 | token                   |    Y     |        -         | Provide `${{ secrets.GITHUB_TOKEN }}` so the action can access the GitHub API                                    |
 | fail_on_same_version    |    N     |     `true`       | Set whether the action should fail if the version exactly matches the latest published tag.                      |
-| tag_regex               |    N     | `\\d+.\\d+.\\d+` | Provide a double escaped string that becomes the regular expression for filtering tags                           |
+| tag_regex               |    N     |   `\d+.\d+.\d+`  | Regular expression for filtering tags                                                                            |
 
 ## This action produces these outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
   tag_regex:
     description: 'Double escaped string that becomes the regular expression for filtering tags'
     required: false
-    default: '\\d+.\\d+.\\d+'
+    default: '\d+.\d+.\d+'
 outputs:
   is_new_version:
     description: 'boolean indicating if this is a new version true = yes '

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: false
     default: 'true'
   tag_regex:
-    description: 'Double escaped string that becomes the regular expression for filtering tags'
+    description: 'Regular expression for filtering tags'
     required: false
     default: '\d+.\d+.\d+'
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Should action fail if the version matches the latest published'
     required: false
     default: 'true'
+  tag_regex:
+    description: 'Double escaped string that becomes the regular expression for filtering tags'
+    required: false
+    default: '\\d+.\\d+.\\d+'
 outputs:
   is_new_version:
     description: 'boolean indicating if this is a new version true = yes '

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/check-version",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Asserts package version is the same or higher than latest published tag",
   "main": "dist/index.mjs",
   "type": "module",

--- a/src/__tests__/checkVersion.test.ts
+++ b/src/__tests__/checkVersion.test.ts
@@ -49,7 +49,10 @@ describe('checkVersion', function () {
   test('filter through an array of tags and return sorted ones per semver rules - default regex', async function () {
     const checkVersion = new CheckVersion(core, fs)
 
-    const res: Tag[] = await checkVersion.filterTags(dummyTags)
+    const res: Tag[] = await checkVersion.filterTags(
+      dummyTags,
+      `\\d+.\\d+.\\d+`
+    )
 
     expect(res[res.length - 1].name).to.equal('v1.2.0')
     expect(res.length).to.equal(expectedGreedyArray.length)

--- a/src/lib/checkVersion.ts
+++ b/src/lib/checkVersion.ts
@@ -49,10 +49,7 @@ export class CheckVersion {
 
       if (tags.length > 0) {
         // filter out tags that don't look like releases
-        sortedTaggedVersions = await this.filterTags(
-          tags,
-          tagRegex ? tagRegex : undefined
-        )
+        sortedTaggedVersions = await this.filterTags(tags, tagRegex)
 
         //newest tag from repo
         newestTag = sortedTaggedVersions[sortedTaggedVersions.length - 1].name
@@ -115,12 +112,10 @@ export class CheckVersion {
     return result
   }
 
-  // default regex is greedy
-  async filterTags(tags: Tag[], tagRegex = `\\d+.\\d+.\\d+`) {
+  async filterTags(tags: Tag[], tagRegex: string) {
     let taggedVersions: Tag[] = []
     try {
       const regex = new RegExp(tagRegex)
-      console.log(`Filtering tags using regex: ${regex}`)
       taggedVersions = tags
         .filter(t => t.name.match(regex))
         .sort((a, b) => semver.compare(a.name, b.name))

--- a/src/lib/checkVersion.ts
+++ b/src/lib/checkVersion.ts
@@ -63,9 +63,9 @@ export class CheckVersion {
         )
         return isNewVersion
       } else {
-        this.core.setOutput('version', `v${version}`)
-        this.core.setOutput('is_new_version', true)
-        this.core.setOutput('build_date', new Date())
+        this.setOutput('version', `v${version}`)
+        this.setOutput('is_new_version', true)
+        this.setOutput('build_date', new Date())
 
         console.log(
           `There are no remote tags, your local version: ${version} is the most recent.`
@@ -133,30 +133,30 @@ export class CheckVersion {
   ): Promise<boolean> {
     const isPrerelease = packageTag.includes('-')
 
-    this.core.setOutput('build_date', new Date())
-    this.core.setOutput('version', `v${packageTag}`)
-    this.core.setOutput('is_prerelease', isPrerelease)
+    this.setOutput('build_date', new Date())
+    this.setOutput('version', `v${packageTag}`)
+    this.setOutput('is_prerelease', isPrerelease)
 
     if (manager === 'npm') {
-      this.core.setOutput('npm_release_tag', isPrerelease ? 'next' : 'latest')
+      this.setOutput('npm_release_tag', isPrerelease ? 'next' : 'latest')
     }
 
     if (semver.compare(newestGithubTag, packageTag) === 1) {
-      this.core.setOutput('is_new_version', false)
+      this.setOutput('is_new_version', false)
 
       this.core.setFailed(
         `Newest tag: ${newestGithubTag} is a higher version than: ${packageTag}`
       )
       return false
     } else if (semver.compare(newestGithubTag, packageTag) === -1) {
-      this.core.setOutput('is_new_version', true)
+      this.setOutput('is_new_version', true)
 
       console.log(
         `Newest tag: ${newestGithubTag} is a lower version than: ${packageTag} \n so we must be releasing new version`
       )
       return true
     } else if (semver.compare(newestGithubTag, packageTag) === 0) {
-      this.core.setOutput('is_new_version', false)
+      this.setOutput('is_new_version', false)
 
       console.log(
         `Newest tag: ${newestGithubTag} is the same version as: ${packageTag} so not a new version`
@@ -172,5 +172,10 @@ export class CheckVersion {
       this.core.setFailed(`no newest tag`)
       return false
     }
+  }
+
+  setOutput(name: string, value: any) {
+    this.core.setOutput(name, value)
+    console.log(`setting output: { "${name}": "${value}" }`)
   }
 }

--- a/src/lib/checkVersion.ts
+++ b/src/lib/checkVersion.ts
@@ -120,6 +120,7 @@ export class CheckVersion {
     let taggedVersions: Tag[] = []
     try {
       const regex = new RegExp(tagRegex)
+      console.log(`Filtering tags using regex: ${regex}`)
       taggedVersions = tags
         .filter(t => t.name.match(regex))
         .sort((a, b) => semver.compare(a.name, b.name))

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,17 +34,11 @@ async function run(core: TypeOfCore): Promise<void> {
       manager: selectManager.manager,
       tagRegex
     })
-    printAllOutputs()
+
+    const outputsFilePath = process.env['GITHUB_OUTPUT']
+    if (outputsFilePath) console.log(await fs.readFile(outputsFilePath, 'utf8'))
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
-  }
-}
-
-function printAllOutputs(): void {
-  for (const key in process.env) {
-    if (key.startsWith('OUTPUT_')) {
-      console.log(`Output ${key}: ${process.env[key]}`)
-    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,6 @@ async function run(core: TypeOfCore): Promise<void> {
       manager: selectManager.manager,
       tagRegex
     })
-
-    const outputsFilePath = process.env['GITHUB_OUTPUT']
-    if (outputsFilePath) console.log(await fs.readFile(outputsFilePath, 'utf8'))
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,8 +34,17 @@ async function run(core: TypeOfCore): Promise<void> {
       manager: selectManager.manager,
       tagRegex
     })
+    printAllOutputs()
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
+  }
+}
+
+function printAllOutputs(): void {
+  for (const key in process.env) {
+    if (key.startsWith('OUTPUT_')) {
+      console.log(`Output ${key}: ${process.env[key]}`)
+    }
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type
- [x] Bug Fix

## High level description

Fixes the forgotten new input to the `action.yml`, which was causing this error. 
![image](https://github.com/user-attachments/assets/bd8028d5-2004-4d71-9a3d-d999112708a7)

Input doesn't need to be double escaped and default can come from the `action.yml` config.
Adds output logs
<img width="943" alt="image" src="https://github.com/user-attachments/assets/449efd04-256e-49e2-9c95-b81016b3437f">


## Describe alternatives you've considered

N/A


