### PR TITLE
chore: add secret scanning workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,8 @@ jobs:
     permissions: {}
     with:
       additional_args: "--ignore-npm-errors"
+
+  scan-secrets:
+    uses: digicatapult/shared-workflows/.github/workflows/scan-secrets.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       security-events: write
     with:
       matrix_commands: '["lint", "depcheck"]'
+      enable_trufflehog_action: true
 
   tests:
     uses: digicatapult/shared-workflows/.github/workflows/tests-npm.yml@main
@@ -32,8 +33,3 @@ jobs:
     permissions: {}
     with:
       additional_args: "--ignore-npm-errors"
-
-  scan-secrets:
-    uses: digicatapult/shared-workflows/.github/workflows/scan-secrets.yml@main
-    permissions:
-      contents: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.5.76",
+  "version": "1.5.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/check-version",
-      "version": "1.5.76",
+      "version": "1.5.77",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.5.76",
+  "version": "1.5.77",
   "description": "Asserts package version is the same or higher than latest published tag",
   "main": "dist/index.mjs",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

[ENG-292](https://digicatapult.atlassian.net/browse/ENG-292)

## High level description

Adds the shared `scan-secrets` workflow (TruffleHog) to CI. This job is already present in `spec-rag-api` and `spec-rag-worker` but was missing here.

## Detailed description

Adds a single job referencing `digicatapult/shared-workflows/.github/workflows/scan-secrets.yml@main` with `contents: read` permission, consistent with the pattern used in other repos in the org.

## Describe alternatives you've considered

No alternatives — this is a like-for-like addition of an existing shared workflow.

## Operational impact

None. CI-only change; no effect on the deployed application.

## Additional context

Part of a compliance audit to ensure consistent secret scanning coverage across all production repos.

[ENG-292]: https://digicatapult.atlassian.net/browse/ENG-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ