### PR TITLE
Add missing Dependency-Track GUID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     secrets:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
+      DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}
 
   publish:
     needs: [check-version, generate-sbom-npm, tests]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.5.97",
+  "version": "1.5.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/check-version",
-      "version": "1.5.97",
+      "version": "1.5.98",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/check-version",
-  "version": "1.5.97",
+  "version": "1.5.98",
   "description": "Asserts package version is the same or higher than latest published tag",
   "main": "dist/index.mjs",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

ENG-323

## High level description

`DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}` was expected by an upstream change to the shared workflows, but it was never picked up per downstream caller. This has been tested already against [digicatapult/hello-world](https://github.com/digicatapult/hello-world).